### PR TITLE
Add support for multiple bloom filter files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool can help a [digital forensic investigator](https://gist.github.com/adu
 
 ~~~~
 usage: hashlookup-analyser.py [-h] [-v] [--extended-debug] [--progress] [--disable-progress] [-d DIR] [--report] [--live-linux] [--print-all] [--print-unknown] [--include-stats] [--format FORMAT] [--cache]
-                              [--bloomfilter BLOOMFILTER]
+                              [--bloomfilters BLOOMFILTER [BLOOMFILTER ...]]
 
 Analyse a forensic target to find and report files found and not found in hashlookup CIRCL public service.
 
@@ -27,15 +27,15 @@ optional arguments:
   --include-stats       Include statistics in the CSV export.
   --format FORMAT       Output format (default is CSV).
   --cache               Enable local cache of known and unknown hashes in /tmp/hashlookup-forensic-analyser.
-  --bloomfilter BLOOMFILTER
-                        Specify filename of a bloomfilter in DCSO bloomfilter format.
+  --bloomfilters BLOOMFILTER [BLOOMFILTER ...]
+                        Space separated list of filenames of bloomfilters in DCSO bloomfilter format.
 ~~~~
 
 ## Sample report
 
 If you want to analyse a specific directory (in this case, a Kernel module directory), the following command be executed:
 
-`python3 hashlookup-analyser.py  --bloomfilter=../hashlookup/hashlookup-full.bloom.1 --report -d /usr/lib/modules/5.11.0-41-generic/`
+`python3 hashlookup-analyser.py  --bloomfilters ../hashlookup/hashlookup-full.bloom.1 --report -d /usr/lib/modules/5.11.0-41-generic/`
 
 When executed with `--report`, a [summary report](./doc/sample-report/summary.md) in Markdown and a full [JSON](./doc/sample-report/full.json) file report are generated.
 
@@ -93,10 +93,10 @@ stats,Analysed directory /usr/local/bin/ on kolmogorov running Linux-5.10.0-1045
 
 If you don't want to share your lookups online and do faster lookup, hashlookup provides a [bloom filter to download](https://cra.circl.lu/hashlookup/hashlookup-full.bloom).
 
-The file is around 700MB and can be stored locally in your home directory. `hashlookup-analyser` works in the same way, `--bloomfilter` option allows to specify the filename location of the bloom filter.
+The file is around 700MB and can be stored locally in your home directory. `hashlookup-analyser` works in the same way, `--bloomfilters` option allows to specify the filename location of the bloom filter (one or more).
 
 ~~~~
-python3 bin/hashlookup-analyser.py --bloomfilter /home/adulau/hashlookup/hashlookup-full.bloom --include-stats -d /bin
+python3 bin/hashlookup-analyser.py --bloomfilters /home/adulau/hashlookup/hashlookup-full.bloom --include-stats -d /bin
 ~~~~
 
 # License

--- a/bin/hashlookup-analyser.py
+++ b/bin/hashlookup-analyser.py
@@ -82,20 +82,26 @@ parser.add_argument(
     default=False,
 )
 parser.add_argument(
-    "--bloomfilter",
-    help="Specify filename of a bloomfilter in DCSO bloomfilter format.",
+    "--bloomfilters",
+    nargs='+',
+    help="Space separated list of filenames of bloomfilters in DCSO bloomfilter format.",
     default=None,
 )
 args = parser.parse_args()
 
-if args.bloomfilter is not None:
+if args.bloomfilters is not None:
     from flor import BloomFilter
 
-    bf = BloomFilter()
-    with open(args.bloomfilter, 'rb') as f:
-        bf.read(f)
-    if b"6F1C170761C212EFD5004DF7FB36CEAF9FB053F7" in bf:
-        bloomfilter_source = "hashlookup-blomfilter"
+    bfs = []
+    for bffile in args.bloomfilters:
+        bf = BloomFilter()
+        with open(bffile, 'rb') as f:
+            bf.read(f)
+        if b"6F1C170761C212EFD5004DF7FB36CEAF9FB053F7" in bf:
+            bloomfilter_source = "hashlookup-bloomfilter_"+bffile
+        else:
+            bloomfilter_source = "bloomfilter-file_"+bffile
+        bfs.append({'bf': bf, 'bloomfilter_source': bloomfilter_source})
 
 if args.live_linux:
     args.dir = '/proc'
@@ -112,13 +118,14 @@ def lookup(value=None):
     if value is None:
         return False
 
-    if args.bloomfilter is not None:
-        if value.encode() in bf:
-            ret = {}
-            ret['SHA-1'] = value
-            return ret
-        else:
-            return False
+    if args.bloomfilters is not None:
+        for bf in bfs:
+            if value.encode() in bf['bf']:
+                ret = {}
+                ret['SHA-1'] = value
+                ret['source'] = bf['bloomfilter_source']
+                return ret
+        return False
 
     r = requests.get(
         f'https://hashlookup.circl.lu/lookup/sha1/{value}', headers=headers

--- a/bin/hashlookup-analyser.py
+++ b/bin/hashlookup-analyser.py
@@ -98,9 +98,9 @@ if args.bloomfilters is not None:
         with open(bffile, 'rb') as f:
             bf.read(f)
         if b"6F1C170761C212EFD5004DF7FB36CEAF9FB053F7" in bf:
-            bloomfilter_source = "hashlookup-bloomfilter_"+bffile
+            bloomfilter_source = "hashlookup-bloomfilter_" + bffile
         else:
-            bloomfilter_source = "bloomfilter-file_"+bffile
+            bloomfilter_source = "bloomfilter-file_" + bffile
         bfs.append({'bf': bf, 'bloomfilter_source': bloomfilter_source})
 
 if args.live_linux:


### PR DESCRIPTION
This PR adds support for multiple bloom filters via the "--bloomfilters x y z" argument.
(cfr https://github.com/hashlookup/hashlookup-forensic-analyser/issues/10)
