### PR TITLE
Fixing typo

### DIFF
--- a/bin/hashlookup-analyser.py
+++ b/bin/hashlookup-analyser.py
@@ -370,7 +370,7 @@ if args.format == "csv":
                 )
 
     if args.include_stats:
-        if args.bloomfilter is not None:
+        if args.bloomfilters is not None:
             bloomfilter_source = bloomfilter_source
         else:
             bloomfilter_source = "None - live request"


### PR DESCRIPTION
Running hashlookup using bloomfilters combined with the --inline-stats flag, python ran into an error due to a typo (missing "s").