### PR TITLE
support BF with lower and/or upper case hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+#IDE settings
+.vscode

--- a/bin/hashlookup-analyser.py
+++ b/bin/hashlookup-analyser.py
@@ -120,7 +120,7 @@ def lookup(value=None):
 
     if args.bloomfilters is not None:
         for bf in bfs:
-            if value.encode() in bf['bf']:
+            if value.encode().lower() in bf['bf'] or value.encode().upper() in bf['bf']:
                 ret = {}
                 ret['SHA-1'] = value
                 ret['source'] = bf['bloomfilter_source']


### PR DESCRIPTION
On line 123 the value of a file is checked against a bloom filter passed by arguments. If the bloom filter was generated using upper case characters the result will be unknown even if the hash is inside the set.

my first approach was to use:
if value.encode() in map(str.lower,bf['bf']):

unfortunately bf is not iterable thus i solved it using an or